### PR TITLE
#22 댓글 기능 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -26,3 +26,11 @@ operation::post-update[snippets='http-request,http-response,request-fields']
 
 === Post 삭제
 operation::post-delete[snippets='http-request,http-response,request-fields']
+
+
+== Comment-API
+
+=== Comment 생성
+operation::comment-create[snippets='http-request,http-response,request-fields']
+
+

--- a/src/main/java/com/minihouse/controller/CommentController.java
+++ b/src/main/java/com/minihouse/controller/CommentController.java
@@ -16,7 +16,7 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @PostMapping("/{postId}")
+    @PostMapping("/{postId}/comments")
     public Long registerComment(@PathVariable Long postId, @RequestBody CommentCreateRequest request) {
         return commentService.create(request.toEntity(postId));
     }

--- a/src/main/java/com/minihouse/controller/CommentController.java
+++ b/src/main/java/com/minihouse/controller/CommentController.java
@@ -1,0 +1,23 @@
+package com.minihouse.controller;
+
+import com.minihouse.request.CommentCreateRequest;
+import com.minihouse.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/posts")
+@RestController
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/{postId}")
+    public Long registerComment(@PathVariable Long postId, @RequestBody CommentCreateRequest request) {
+        return commentService.create(request.toEntity(postId));
+    }
+}

--- a/src/main/java/com/minihouse/domain/Comment.java
+++ b/src/main/java/com/minihouse/domain/Comment.java
@@ -1,0 +1,29 @@
+package com.minihouse.domain;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Comment {
+
+    private final Long id;
+    private final String content;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+    private final Long postId;
+    private final Long userId;
+    private final Long commentId;
+
+    @Builder
+    public Comment(Long id, String content, LocalDateTime createdAt, LocalDateTime updatedAt,
+        Long postId, Long userId, Long commentId) {
+        this.id = id;
+        this.content = content;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.postId = postId;
+        this.userId = userId;
+        this.commentId = commentId;
+    }
+}

--- a/src/main/java/com/minihouse/repository/CommentRepository.java
+++ b/src/main/java/com/minihouse/repository/CommentRepository.java
@@ -1,0 +1,12 @@
+package com.minihouse.repository;
+
+import com.minihouse.domain.Comment;
+import org.apache.ibatis.annotations.Mapper;
+import org.springframework.stereotype.Repository;
+
+@Mapper
+@Repository
+public interface CommentRepository {
+
+    void save(Comment comment);
+}

--- a/src/main/java/com/minihouse/request/CommentCreateRequest.java
+++ b/src/main/java/com/minihouse/request/CommentCreateRequest.java
@@ -1,0 +1,29 @@
+package com.minihouse.request;
+
+import com.minihouse.domain.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentCreateRequest {
+
+    private String content;
+    private Long userId;
+
+    public CommentCreateRequest() {
+    }
+
+    @Builder
+    public CommentCreateRequest(String content, Long userId) {
+        this.content = content;
+        this.userId = userId;
+    }
+
+    public Comment toEntity(Long postId) {
+        return Comment.builder()
+            .content(content)
+            .postId(postId)
+            .userId(userId)
+            .build();
+    }
+}

--- a/src/main/java/com/minihouse/service/CommentService.java
+++ b/src/main/java/com/minihouse/service/CommentService.java
@@ -17,12 +17,12 @@ public class CommentService {
 
     @Transactional
     public Long create(Comment comment) {
-        validCreateComment(comment);
+        verifyExistPost(comment);
         commentRepository.save(comment);
         return comment.getId();
     }
 
-    private void validCreateComment(Comment comment) {
+    private void verifyExistPost(Comment comment) {
         Post findPostById = postRepository.findById(comment.getPostId());
         if (findPostById == null) {
             throw new IllegalArgumentException("존재하지 않는 게시글입니다.");

--- a/src/main/java/com/minihouse/service/CommentService.java
+++ b/src/main/java/com/minihouse/service/CommentService.java
@@ -1,0 +1,31 @@
+package com.minihouse.service;
+
+import com.minihouse.domain.Comment;
+import com.minihouse.domain.Post;
+import com.minihouse.repository.CommentRepository;
+import com.minihouse.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    @Transactional
+    public Long create(Comment comment) {
+        validCreateComment(comment);
+        commentRepository.save(comment);
+        return comment.getId();
+    }
+
+    private void validCreateComment(Comment comment) {
+        Post findPostById = postRepository.findById(comment.getPostId());
+        if (findPostById == null) {
+            throw new IllegalArgumentException("존재하지 않는 게시글입니다.");
+        }
+    }
+}

--- a/src/main/resources/db/migration/V2.1__modify_column_default_value.sql
+++ b/src/main/resources/db/migration/V2.1__modify_column_default_value.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `comments` MODIFY created_at timestamp DEFAULT CURRENT_TIMESTAMP;

--- a/src/main/resources/db/migration/V2__create_table_comment.sql
+++ b/src/main/resources/db/migration/V2__create_table_comment.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS `comments`;
+CREATE TABLE `comments`
+(
+    `id`         bigint PRIMARY KEY AUTO_INCREMENT,
+    `content`    text,
+    `created_at` timestamp,
+    `updated_at` timestamp,
+    `post_id`    bigint,
+    `user_id`    bigint,
+    `comment_id` bigint
+);
+
+ALTER TABLE `comments`
+    ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
+ALTER TABLE `comments`
+    ADD FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`);

--- a/src/main/resources/mybatis/mapper/commentMapper.xml
+++ b/src/main/resources/mybatis/mapper/commentMapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+  "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.minihouse.repository.CommentRepository">
+  <insert id="save" useGeneratedKeys="true" keyProperty="id">
+    INSERT INTO comments (content, created_at, post_id, user_id)
+    VALUES (#{content}, now(), #{postId}, #{userId})
+    <selectKey keyProperty="id" resultType="Long">
+      SELECT LAST_INSERT_ID()
+    </selectKey>
+  </insert>
+
+</mapper>

--- a/src/main/resources/schema/comment-schema.sql
+++ b/src/main/resources/schema/comment-schema.sql
@@ -1,0 +1,16 @@
+DROP TABLE IF EXISTS `comments`;
+CREATE TABLE `comments`
+(
+    `id`         bigint PRIMARY KEY AUTO_INCREMENT,
+    `content`    text,
+    `created_at` timestamp,
+    `updated_at` timestamp,
+    `post_id`    bigint,
+    `user_id`    bigint,
+    `comment_id` bigint
+);
+
+ALTER TABLE `comments`
+    ADD FOREIGN KEY (`user_id`) REFERENCES `users` (`id`);
+ALTER TABLE `comments`
+    ADD FOREIGN KEY (`post_id`) REFERENCES `posts` (`id`);

--- a/src/test/java/com/minihouse/controller/CommentControllerTest.java
+++ b/src/test/java/com/minihouse/controller/CommentControllerTest.java
@@ -1,0 +1,74 @@
+package com.minihouse.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.minihouse.domain.Comment;
+import com.minihouse.request.CommentCreateRequest;
+import com.minihouse.service.CommentService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@AutoConfigureRestDocs
+@ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
+@WebMvcTest(CommentController.class)
+class CommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private CommentService commentService;
+
+    @Test
+    @DisplayName("댓글 등록 api")
+    void registerComment() throws Exception {
+
+        // given
+        CommentCreateRequest request = CommentCreateRequest.builder()
+            .content("테스트댓글")
+            .userId(1L)
+            .build();
+
+        given(commentService.create(any(Comment.class))).willReturn(any());
+
+        // when
+        ResultActions result = mockMvc.perform(post("/api/v1/posts/{postId}", 1)
+            .content(objectMapper.writeValueAsString(request))
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isOk())
+            .andDo(document("comment-create",
+                preprocessRequest(prettyPrint()),
+                preprocessResponse(prettyPrint()),
+                requestFields(
+                    fieldWithPath("content").description("댓글 내용"),
+                    fieldWithPath("userId").description("유저 아이디"))))
+            .andDo(print());
+    }
+}

--- a/src/test/java/com/minihouse/controller/CommentControllerTest.java
+++ b/src/test/java/com/minihouse/controller/CommentControllerTest.java
@@ -57,7 +57,7 @@ class CommentControllerTest {
         given(commentService.create(any(Comment.class))).willReturn(any());
 
         // when
-        ResultActions result = mockMvc.perform(post("/api/v1/posts/{postId}", 1)
+        ResultActions result = mockMvc.perform(post("/api/v1/posts/{postId}/comments", 1)
             .content(objectMapper.writeValueAsString(request))
             .contentType(MediaType.APPLICATION_JSON));
 

--- a/src/test/java/com/minihouse/service/CommentServiceTest.java
+++ b/src/test/java/com/minihouse/service/CommentServiceTest.java
@@ -1,0 +1,82 @@
+package com.minihouse.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+import com.minihouse.domain.Comment;
+import com.minihouse.domain.Post;
+import com.minihouse.repository.CommentRepository;
+import com.minihouse.repository.PostRepository;
+import com.minihouse.request.CommentCreateRequest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @InjectMocks
+    private CommentService commentService;
+
+    @Test
+    @DisplayName("댓글을 작성할 수 있다.")
+    void create() {
+        // given
+        Long postId = 1L;
+        CommentCreateRequest request = CommentCreateRequest.builder()
+            .content("테스트 댓글")
+            .userId(1L)
+            .build();
+
+        Post post = Post.builder()
+            .id(1L)
+            .title("제목입니다.")
+            .content("내용입니다.")
+            .build();
+
+        Comment comment = request.toEntity(postId);
+
+        given(postRepository.findById(postId)).willReturn(post);
+        doNothing().when(commentRepository).save(isA(Comment.class));
+
+        // when
+
+        Long commentId = commentService.create(comment);
+
+        // then
+        verify(commentRepository).save(comment);
+        Assertions.assertThat(comment.getId()).isEqualTo(commentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 게시글에는 댓글을 달 수 없다.")
+    void canNotCommentOnPostThatDoesNotExist() {
+        // given
+        Long postId = 1L;
+        CommentCreateRequest request = CommentCreateRequest.builder()
+            .content("테스트 댓글")
+            .userId(1L)
+            .build();
+
+        Comment comment = request.toEntity(postId);
+
+        given(postRepository.findById(postId)).willReturn(null);
+
+        // expected
+        assertThatThrownBy(() -> commentService.create(comment))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## 개요
댓글 기능 추가

## 작업사항
댓글 기능 추가

## 고민한 부분
- 유튜브 댓글 처럼 댓글 밑에 대댓글(depth 1번)만 달 수 있도록 하고 싶습니다.
- 그래서 고민한게 댓글 테이블에 `commentId` 라는 컬럼을 넣고, 일반 댓글은 `null`, 대댓글이라면 부모의 `id` 를 넣어서 구현하려고 합니다.